### PR TITLE
Add library names for Fedora (based on Fedora 33)

### DIFF
--- a/flomat/flomat.rkt
+++ b/flomat/flomat.rkt
@@ -89,18 +89,23 @@
     [(unix)
      ; Note: The library names are different on Debian, Ubuntu and Arch.
      (define uname (string-downcase (system-type 'machine)))
-     (define dist  (cond [(regexp-match "arch"   uname) 'arch]
-                         [(regexp-match "debian" uname) 'debian]
-                         [(regexp-match "ubuntu" uname) 'ubuntu]
-                         [else                          'other]))
+     (define dist  (cond [(regexp-match "arch"        uname) 'arch]
+                         [(regexp-match "debian"      uname) 'debian]
+                         [(regexp-match "ubuntu"      uname) 'ubuntu]
+                         [(regexp-match #px"fc\\d\\d" uname) 'fedora]
+                         [else                               'other]))
      ; The lib order is important here.
      (define cblas-lib    (case dist
-                            [(debian) (ffi-lib "libblas"    '("3" #f))]
-                            [(arch)   (ffi-lib "libcblas"   '("3" #f))]
-                            [(ubuntu) (ffi-lib "libblas"    '("3" #f))] 
-                            [(other)  (ffi-lib "libblas"    '("3" #f))]))
+                            [(debian) (ffi-lib "libblas"  '("3" #f))]
+                            [(arch)   (ffi-lib "libcblas" '("3" #f))]
+                            [(ubuntu) (ffi-lib "libblas"  '("3" #f))] 
+                            [(fedora) (ffi-lib "libcblas" '("3" #f))] 
+                            [(other)  (ffi-lib "libblas"  '("3" #f))]))
                             
-     (define gfortran-lib (ffi-lib "libgfortran" '("3" #f)))
+     (define gfortran-lib (case dist
+                            [(fedora) (ffi-lib "libgfortran" '("5" #f))]
+                            [else     (ffi-lib "libgfortran" '("3" #f))]))
+
      (define quadmath-lib (ffi-lib "libquadmath" '("0" #f)))
      (define lapack-lib   (ffi-lib "liblapack"   '("3" #f)))
      (values cblas-lib lapack-lib)]


### PR DESCRIPTION
Hello,

this PR adds support for Fedora 33, `'fedora` is added to the distribution list and blas and fortran libraries are set the following way:

* `libcblas.so.3` instead of `libblas.so.3` - the correct symbols are exported from the former
* `libgfortran.so.5` instead of `libgfortran.so.3` - `3` is not available in Fedora, see:

```
$ dnf provides libgfortran.so.3
Last metadata expiration check: 18:29:56 ago on Fri 11 Dec 2020 09:58:17 PM CET.
Error: No Matches found
```

These changes are based on Fedora 33 and I am not sure about the granularity. I saw there are no versions for the other distros, so I went for a general `'fedora` distribution, although I only tested on 33. Shall I change it to match only 33 and use a more granular way? eg `fedora33`?

My system is identified by that `fc33` part of the following string, I set the regex to expect `fc` + 2 digits for Fedora.

```
> (system-type 'machine)
"Linux mrau 5.9.10-200.fc33.x86_64 #1 SMP Mon Nov 23 18:12:50 UTC 2020 x86_64 x86_64 x86_64 GNU/Linux
```

Test run:

```
$ raco test flomat.rkt
raco test: (submod "flomat.rkt" test)
82 tests passed
```